### PR TITLE
Add initial version of 3scale alert SOPs included on 3scale v2.9

### DIFF
--- a/docs/day-2-operations/Observability.adoc
+++ b/docs/day-2-operations/Observability.adoc
@@ -1,0 +1,19 @@
+:toc:
+:toc-placement!:
+
+= Observability
+
+toc::[]
+
+== Monitoring
+
+* From 3scale 2.9, link:https://github.com/3scale/3scale-operator[3scale-operator] creates `PrometheusRule` objects in order to add some useful prometheus alerts based on 3scale builtin application metrics, but also  some alerts based on kube-state-metrics and cAdvisor (kubelet) metrics
+
+* You can check current SOP alerts at link:../../sops/alerts[sops/alerts] directory
+
+== Dashboards
+
+* From 3scale 2.9, link:https://github.com/3scale/3scale-operator[3scale-operator] creates `GrafanaDashboard` objects with grafana dashboards of different 3scale components (backend, zync, apicast...) and also a couple of generic dashboards with kubernetes resources usage by pod and namespace where 3scale is deployed.
+
+
+

--- a/sops/README.adoc
+++ b/sops/README.adoc
@@ -1,0 +1,11 @@
+= SOPS (Standard Operating Procedures)
+
+For each alert defined, there should be some associated documentation that explains what the alert means, what the likely cause is and how to respond to the alert. These SOPs are essential to enabling an SRE team to effectively respond to alerts without needing direct input from an Engineering team. Without these, an SRE team will be aware that there is an ongoing problem, but will not have the necessary knowledge to deal with the problem.
+
+Common sections in a SOP may include:
+
+* Assumptions - how to validate that the alert is actually highlighting a problem, and what prerequisites might be required
+* Reference Articles - where to find additional information, or prior art for linked/similar issues
+* Corrective Process - what steps to take to resolve the issue
+* Success Indicators - how to know when the issue is resolved
+* Other Notes - any other relevant information

--- a/sops/alerts/apicast_apicast_latency.adoc
+++ b/sops/alerts/apicast_apicast_latency.adoc
@@ -1,0 +1,23 @@
+:toc:
+:toc-placement!:
+
+= ThreescaleApicastLatencyHigh
+
+toc::[]
+
+== Description
+
+* This alert will trigger if the `apicast-staging`/`apicast-production` **p99** latency is greater than a given threshold
+* Latency metric includes the time the request spent in apicast plus the time it took the upstream to respond
+
+== Troubleshooting
+
+* Check if `apicast-staging`/`apicast-production` pods might not be able to deal with incoming traffic due to high CPU usage
+- You may need to consider scaling horinzontally `apicast-staging`/`apicast-production` deployment
+- You may need to consider increasing `apicast-staging`/`apicast-production` deployment resources requests/limits
+* Check if upstream response is taking too much time
+* Check if the current traffic is normal based on the historical data. An unexpected change in the traffic pattern can be legit, and will require scaling up, but it also can be due to an abnormal or malicious traffic
+
+== Verification
+
+* Alert should disappear once the `apicast-staging`/`apicast-production` **p99** latency is below the threshold

--- a/sops/alerts/apicast_http_4xx_error_rate.adoc
+++ b/sops/alerts/apicast_http_4xx_error_rate.adoc
@@ -1,0 +1,24 @@
+:toc:
+:toc-placement!:
+
+= ThreescaleApicastHttp4xxErrorRate
+
+toc::[]
+
+== Description
+
+* This alert will trigger if the error rate of `apicast-staging`/`apicast-production` HTTP 4XX requests is greater than a given threshold
+
+== Troubleshooting
+
+* Check if `apicast-staging`/`apicast-production` pods might be failing
+* Check `apicast-staging`/`apicast-production` pod logs to see if:
+- Auth is not valid
+- Service/Mapping rule is not being found (either it does not exists in `system-app` or `system-app` is having issues and not returning the required configuration )
+- Upstream is sending a 4XX status code
+- Used policy is configured to send 4XX status code
+
+
+== Verification
+
+* Alert should disappear once the error rate of `apicast-staging`/`apicast-production` HTTP 4XX requests is below the threshold

--- a/sops/alerts/apicast_request_time.adoc
+++ b/sops/alerts/apicast_request_time.adoc
@@ -1,0 +1,22 @@
+:toc:
+:toc-placement!:
+
+= ThreescaleApicastRequestTime
+
+toc::[]
+
+== Description
+
+* This alert will trigger if there is a huge number of `apicast-staging`/`apicast-production` requests being processed slow (below a given threshold)
+* Request time metric includes only the time the request spent in apicast
+
+== Troubleshooting
+
+* Check if `apicast-staging`/`apicast-production` pods might not be able to deal with incoming traffic due to high CPU usage
+- You may need to consider scaling horinzontally `apicast-staging`/`apicast-production` deployment
+- You may need to consider increasing `apicast-staging`/`apicast-production` deployment resources requests/limits
+* Check if the current traffic is normal based on the historical data. An unexpected change in the traffic pattern can be legit, and will require scaling up, but it also can be due to an abnormal or malicious traffic
+
+== Verification
+
+* Alert should disappear once the number of `apicast-staging`/`apicast-production` slow requests are below the threshold

--- a/sops/alerts/backend_listener_5xx_requests_high.adoc
+++ b/sops/alerts/backend_listener_5xx_requests_high.adoc
@@ -1,0 +1,23 @@
+:toc:
+:toc-placement!:
+
+= ThreescaleBackendListener5XXRequestsHigh
+
+toc::[]
+
+== Description
+
+* This alert will trigger if the number of `backend-listener` HTTP 5XX requests is greater than a given threshold
+
+== Troubleshooting
+
+* Check if `backend-listener` pods might be failing
+* Check if `backend-listener` pods might not be able to deal with incoming traffic due to high CPU usage
+- You may need to consider scaling horinzontally `backend-listener` deployment
+- You may need to consider increasing `backend-listener` deployment resources requests/limits
+* Check if backend's redis is having issues
+* Check if the current traffic is normal based on the historical data. An unexpected change in the traffic pattern can be legit, and will require scaling up, but it also can be due to an abnormal or malicious traffic
+
+== Verification
+
+* Alert should disappear once the number of `backend-listener` HTTP 5XX requests is below the threshold

--- a/sops/alerts/backend_worker_jobs_count_running_high.adoc
+++ b/sops/alerts/backend_worker_jobs_count_running_high.adoc
@@ -1,0 +1,23 @@
+:toc:
+:toc-placement!:
+
+= ThreescaleBackendWorkerJobsCountRunningHigh
+
+toc::[]
+
+== Description
+
+* This alert will trigger if the number of `backend-worker` jobs is greater than a given threshold
+
+== Troubleshooting
+
+* Check if `backend-worker` pods might be failing and the jobs are not being consumed at all from backend's redis
+* Check if `backend-worker` pods might not be consuming jobs at the required throughput:
+- You may need to consider scaling horinzontally `backend-worker` deployment
+- You may need to consider increasing `backend-worker` deployment resources requests/limits
+* Check if the current traffic in `backend-listener` is normal based on the historical data. An unexpected change in the traffic pattern can be legit, and will require scaling up, but it also can be due to an abnormal or malicious traffic. Whatever the reason, increased traffic in `backend-listener` generates more jobs for `backend-worker` to process from backend's redis
+* Check if backend's redis is having issues
+
+== Verification
+
+* Alert should disappear once the number of `backend-worker` jobs is below the threshold

--- a/sops/alerts/container_cpu_high.adoc
+++ b/sops/alerts/container_cpu_high.adoc
@@ -1,0 +1,20 @@
+:toc:
+:toc-placement!:
+
+= ThreescaleContainerCPUHigh
+
+toc::[]
+
+== Description
+
+* This alert will trigger if the cpu usage is being very high
+
+== Troubleshooting
+
+* Check if CPU resources requests/limits are properly set and appropriate to the historical usage data. If the real usage tends to surpass the requested threshold, you may need to increase the container resources
+* Check if maybe you need to scale horizontally the associated deployment with more pods (if possible) to distribute the load
+- Some deployments **cannot** be scaled horizontally: `backend-cron` and any db (`backend-redis`,`system-redis`, `system-mysql`, `system-memcache`, `system-sphinx`, `zync-database`)
+
+== Verification
+
+* Alert should disappear once CPU usage decreases below the threshold

--- a/sops/alerts/container_cpu_throttling_high.adoc
+++ b/sops/alerts/container_cpu_throttling_high.adoc
@@ -1,0 +1,19 @@
+:toc:
+:toc-placement!:
+
+= ThreescaleContainerCPUThrottlingHigh
+
+toc::[]
+
+== Description
+
+* This alert will trigger if the cpu usage is being throttled (using more resources than configured)
+
+== Troubleshooting
+
+* Check if CPU resources requests/limits are properly set and appropriate to the historical usage data. If the real usage tends to surpass the requested threshold, you may need to increase the container resources
+
+== Verification
+
+* Alert should disappear once CPU usage is stable
+

--- a/sops/alerts/container_memory_high.adoc
+++ b/sops/alerts/container_memory_high.adoc
@@ -1,0 +1,20 @@
+:toc:
+:toc-placement!:
+
+= ThreescaleContainerMemoryHigh
+
+toc::[]
+
+== Description
+
+* This alert will trigger if the memory usage is being very high
+
+== Troubleshooting
+
+* Check if Memory resources requests/limits are properly set and appropriate to the historical usage data. If the real usage tends to surpass the requested threshold, you may need to increase the container resources
+* Check if maybe you need to scale horizontally the associated deployment with more pods (if possible) to distribute the load
+- Some deployments **cannot** be scaled horizontally: `backend-cron` and any db (`backend-redis`,`system-redis`, `system-mysql`, `system-memcache`, `system-sphinx`, `zync-database`)
+
+== Verification
+
+* Alert should disappear once Memory usage decreases below the threshold

--- a/sops/alerts/container_waiting.adoc
+++ b/sops/alerts/container_waiting.adoc
@@ -1,0 +1,20 @@
+:toc:
+:toc-placement!:
+
+= ThreescaleContainerWaiting
+
+toc::[]
+
+== Description
+
+* This alert will trigger if a container has been in `waiting` state for longer than 1 hour
+
+== Troubleshooting
+
+* Check if maybe container image registry is not reachable
+
+== Verification
+
+* Alert should disappear once container is up and running
+
+

--- a/sops/alerts/pod_crash_looping.adoc
+++ b/sops/alerts/pod_crash_looping.adoc
@@ -1,0 +1,19 @@
+:toc:
+:toc-placement!:
+
+= ThreescalePodCrashLooping
+
+toc::[]
+
+== Description
+
+* This alert will trigger if a pod is on `CrashLoop` state because one of the containers crashes and is restarted indefinitely
+
+== Troubleshooting
+
+* Check pod logs/events to see the reason of the `CrashLoop`
+* Check if maybe container resources requests/limits are too low and OOMKiller is acting (container trying to allocate more memory than permitted)
+
+== Verification
+
+* Alert should disappear once the pod is up and running

--- a/sops/alerts/pod_not_ready.adoc
+++ b/sops/alerts/pod_not_ready.adoc
@@ -1,0 +1,18 @@
+:toc:
+:toc-placement!:
+
+= ThreescalePodNotReady
+
+toc::[]
+
+== Description
+
+* This alert will trigger if a pod is **not** on `Ready` state
+
+== Troubleshooting
+
+* Execute a describe pod command to check the pod status 
+
+== Verification
+
+* Alert should disappear once pod passes the readiness probe

--- a/sops/alerts/prometheus_job_down.adoc
+++ b/sops/alerts/prometheus_job_down.adoc
@@ -1,0 +1,21 @@
+:toc:
+:toc-placement!:
+
+= ThreescalePrometheusJobDown
+
+toc::[]
+
+== Description
+
+* This alert willl trigger when a prometheus Job is Down, because `ServiceMonitor`/`PodMonitor` might have issues to scrape the application `Service`/`Pods`
+* This alert is important because if you have alerts based on application metrics that cannot be obtained because its associated prometheus job is failing you will lose visibility of the application
+
+== Troubleshooting
+
+* Check if the scrapped application (or app metrics endpoint) might be failing and the scrape can not be done
+* Check if `ServiceMonitor`/`PodMonitor` might be misconfigured pointing to incorrect label, port, path...
+* Check if prometheus is having some problems, or if prometheus has not reload its config with possible new `ServiceMonitor`/`PodMonitor`
+
+== Verification
+
+* Alert should disappear once prometheus target starts scrapping all pods

--- a/sops/alerts/replication_controller_replicas_mismatch.adoc
+++ b/sops/alerts/replication_controller_replicas_mismatch.adoc
@@ -1,0 +1,19 @@
+:toc:
+:toc-placement!:
+
+= ThreescaleReplicationControllerReplicasMismatch
+
+toc::[]
+
+== Description
+
+* This alert will trigger if a `ReplicationController` does not have the desired number of pods running
+
+== Troubleshooting
+
+* Check if the new pods created by the replicaset might be failing
+* Check if there might be an issue with the scheduling due to lack of nodes resources or tolerations
+
+== Verification
+
+* Alert should disappear once all pods are running per `ReplicationController` (running pods = desired pods)

--- a/sops/alerts/zync_5xx_requests_high.adoc
+++ b/sops/alerts/zync_5xx_requests_high.adoc
@@ -1,0 +1,22 @@
+:toc:
+:toc-placement!:
+
+= ThreescaleZync5XXRequestsHigh
+
+toc::[]
+
+== Description
+
+* This alert will trigger if the number of `zync` HTTP 5XX requests is greater than a given threshold
+
+== Troubleshooting
+
+* Check if `zync` pods might be failing
+* Check if `zync` pods might not be able to deal with incoming traffic due to high CPU usage
+- You may need to consider scaling horinzontally `zync` deployment
+- You may need to consider increasing `zync` deployment resources requests/limits
+* Check if zync's postgres database is having issues
+
+== Verification
+
+* Alert should disappear once the number of `zync` HTTP 5XX requests is below the threshold

--- a/sops/alerts/zync_que_failed_job_count_high.adoc
+++ b/sops/alerts/zync_que_failed_job_count_high.adoc
@@ -1,0 +1,19 @@
+:toc:
+:toc-placement!:
+
+= ThreescaleZyncQueFailedJobCountHigh
+
+toc::[]
+
+== Description
+
+* This alert will trigger if the number of `zync-que` **failed** jobs is greater than a given threshold
+* **Failed** jobs are the ones that failed at least once, did not run out of attempts to retry and therefore are scheduled for retry any time soon
+
+== Troubleshooting
+
+* Check the logs at `zync-que` pods to see the reason of the failures
+
+== Verification
+
+* Alert should disappear once the number of `zync-que` **failed** jobs is below the threshold

--- a/sops/alerts/zync_que_ready_job_count_high.adoc
+++ b/sops/alerts/zync_que_ready_job_count_high.adoc
@@ -1,0 +1,23 @@
+:toc:
+:toc-placement!:
+
+= ThreescaleZyncQueReadyJobCountHigh
+
+toc::[]
+
+== Description
+
+* This alert will trigger if the number of `zync-que` **ready** jobs is greater than a given threshold
+* **Ready** jobs are the ones that are enqueued and ready to be executed ASAP (never failed, nor got expired)
+
+== Troubleshooting
+
+* Check if `zync-que` pods might be failing and the jobs are not being consumed at all from zync's postgres
+* Check if `zync-que` pods might not be consuming jobs at the required throughput:
+- You may need to consider scaling horinzontally `zync-que` deployment
+- You may need to consider increasing `zync-que` deployment resources requests/limits
+* Check if zync's postgres is having issues
+
+== Verification
+
+* Alert should disappear once the number of `zync-que` **ready** jobs is below the threshold

--- a/sops/alerts/zync_que_scheduled_job_count_high.adoc
+++ b/sops/alerts/zync_que_scheduled_job_count_high.adoc
@@ -1,0 +1,23 @@
+:toc:
+:toc-placement!:
+
+= ThreescaleZyncQueScheduledJobCountHigh
+
+toc::[]
+
+== Description
+
+* This alert will trigger if the number of `zync-que` **scheduled** jobs is greater than a given threshold
+* **Scheduled** jobs are the ones that are enqueued to be executed some time in the future, but not now (never failed, nor got expired)
+
+== Troubleshooting
+
+* Check if `zync-que` pods might be failing and the jobs are not being consumed at all from zync's postgres
+* Check if `zync-que` pods might not be consuming jobs at the required throughput:
+- You may need to consider scaling horinzontally `zync-que` deployment
+- You may need to consider increasing `zync-que` deployment resources requests/limits
+* Check if zync's postgres is having issues
+
+== Verification
+
+* Alert should disappear once the number of `zync-que` **scheduled** jobs is below the threshold


### PR DESCRIPTION
Solves part of https://github.com/3scale/platform/issues/355

- It adds  initial SOP for every current 3scale alert added to 3scale-operator on `v2.9` on asciidoc format (as all repository documentation)
- Once all alert SOPs have been carefully reviewed by 3scale SRE/Ops team, they will be merged to master
- Later on, each 3scale engineering subteam will review its own alerts to add extra domain knowledge information
- In addition, ideally 3scale support team will also review them
- Finally, all 3sacle alerts defined at https://github.com/3scale/platform/issues/355 will include a link to each SOP on an annotation called `sop_url` 