### PR TITLE
[THREESCALE-7203] Fix Zync resync command in Backups.docs

### DIFF
--- a/docs/day-2-operations/Backups.adoc
+++ b/docs/day-2-operations/Backups.adoc
@@ -541,7 +541,7 @@ Resync domains
 
 [source,bash]
 ----
-oc exec -t $(oc get pods -l 'deploymentConfig=system-sidekiq' -o json | jq '.items[0].metadata.name' -r)  bash -- -c "bundle exec rake zync:resync:domains"
+oc exec -t $(oc get pods -l 'deploymentConfig=system-sidekiq' -o json | jq '.items[0].metadata.name' -r) -- bash -c "bundle exec rake zync:resync:domains"
 ----
 
 == Open Issues


### PR DESCRIPTION
Found a typo in command for Resync domains for creating equivalent Zync routes in Backups.adoc
