### PR TITLE
Feat/Update 3scale-operator application observability documentation

### DIFF
--- a/docs/ha_3scale.adoc
+++ b/docs/ha_3scale.adoc
@@ -7,9 +7,9 @@ toc::[]
 
 == Highly available 3scale-operator based installation
 
-This section explains how to install 3scale using the link:https://github.com/3scale/3scale-operator[3scale Operator] and how to configure it to have a highly-available deployment. If you haven't done so, you need to install the 3scale-operator following link:https://github.com/3scale/3scale-operator/blob/3scale-2.10-stable/doc/operator-user-guide.md#installing-3scale[this guide] before proceeding.
+This section explains how to install 3scale using the link:https://github.com/3scale/3scale-operator[3scale Operator] and how to configure it to have a highly-available deployment. If you haven't done so, you need to install the 3scale-operator following link:https://github.com/3scale/3scale-operator/blob/master/doc/operator-user-guide.md#installing-3scale[this guide] before proceeding.
 
-As usual, to install 3scale using the 3scale-operator, an APIManager custom resource is used (see a simple example link:https://github.com/3scale/3scale-operator/blob/3scale-2.10-stable/doc/operator-user-guide.md#basic-installation[here]), but several changes need to be made to ensure a highly-available installation. The following sections delve into each of the changes required.
+As usual, to install 3scale using the 3scale-operator, an APIManager custom resource is used (see a simple example link:https://github.com/3scale/3scale-operator/blob/master/doc/operator-user-guide.md#basic-installation[here]), but several changes need to be made to ensure a highly-available installation. The following sections delve into each of the changes required.
 
 === External databases
 
@@ -82,7 +82,7 @@ In the following example, unlike in the previous one, a *hard podAntiAffinity* c
 
 Enabling Pod disruption budgets (PDBs) ensures that a minimum number of Pods will be available for each component. You can read more about PDBs in the link:https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets[Kubernetes docs].
 
-Pod disruption budgets configuration is documented in link:https://github.com/3scale/3scale-operator/blob/3scale-2.10-stable/doc/operator-user-guide.md#enabling-pod-disruption-budgets[the user guide].
+Pod disruption budgets configuration is documented in link:https://github.com/3scale/3scale-operator/blob/master/doc/operator-user-guide.md#enabling-pod-disruption-budgets[the user guide].
 
 '''
 

--- a/docs/ha_dbs.adoc
+++ b/docs/ha_dbs.adoc
@@ -13,7 +13,7 @@ In order to set up HA for the 3scale databases, you need to tell the operator th
 * Relational database used by *System*
 * And starting from 3scale v2.10, also *Zync* database
 
-To do so, follow link:https://github.com/3scale/3scale-operator/blob/3scale-2.10-stable/doc/operator-user-guide.md#external-databases-installation[these instructions], these are the required APIManager spec fields to tell the operator to work with external databases:
+To do so, follow link:https://github.com/3scale/3scale-operator/blob/master/doc/operator-user-guide.md#external-databases-installation[these instructions], these are the required APIManager spec fields to tell the operator to work with external databases:
 ```yaml
 apiVersion: apps.3scale.net/v1alpha1
 kind: APIManager

--- a/docs/observability.adoc
+++ b/docs/observability.adoc
@@ -7,15 +7,30 @@ toc::[]
 
 == Application metrics
 
-=== Monitoring
+You can link:https://github.com/3scale/3scale-operator/blob/master/doc/operator-monitoring-resources.md#enabling-3scale-monitoring[enable 3scale monitoring] configuring the following APIManager spec fields:
 
-* From 3scale `v2.9`, link:https://github.com/3scale/3scale-operator[3scale Operator] creates `PrometheusRule` objects in order to add some useful prometheus alerts based on 3scale builtin application metrics, but also on kube-state-metrics and cAdvisor (kubelet) metrics (cpu, memory, pod availability...)
+```yaml
+apiVersion: apps.3scale.net/v1alpha1
+kind: APIManager
+metadata:
+  name: example-apimanager
+spec:
+  monitoring:
+    enabled: true  # Mandatory, deploys PodMonitors, GrafanaDashboards and PrometheusRules
+    enablePrometheusRules: false # Optional, not deploy PrometheusRules
+```
 
-* You can check current SOP alerts at link:../sops/alerts[sops/alerts] directory
+link:https://github.com/3scale/3scale-operator[3scale Operator] will:
 
-=== Dashboards
-
-* From 3scale `v2.9`, link:https://github.com/3scale/3scale-operator[3scale Operator] creates `GrafanaDashboard` objects with grafana dashboards of different 3scale components (backend, zync, apicast, system...) and also a couple of generic dashboards with kubernetes resources usage by pod and namespace where the 3scale instance is deployed
+* Create a *PodMonitor* custom resource for every DeployConfig, so prometheus-operator knows how to scrape metrics from every pod
+* Create a *GrafanaDashboard* custom resource for every 3scale component:
+- There are dasboards for every 3scale component: Backend, System, Zync, Apicast, Apicast Services
+- In addition, there are a couple of generic dashboards with kubernetes resources usage by pod and namespace where the 3scale instance is deployed
+* Create a *PrometheusRule* custom resource for every 3scale component:
+- You can check default alerts at link:https://github.com/3scale/3scale-operator/tree/master/doc/prometheusrules[3scale Operator repository]
+- As alerts management can be very customizable, to not force anyone using them, they can be disabled from operator management by adding the optional field `enablePrometheusRules: false`
+- Having access to default PrometheusRules custom resources, you can deploy manually the ones you prefer by link:https://github.com/3scale/3scale-operator/tree/master/doc/prometheusrules#tune-the-prometheus-rules-based-on-your-infraestructure[tunning them to your own needs] (updating severity, time duration, thresholds...)
+- Bear in mind that every default PrometheusRule has a linked SOP (Standard Operating Procedures) on an annotation, you can check current SOP alerts at link:../sops/alerts[sops/alerts] directory
 
 == Databases metrics
 


### PR DESCRIPTION
Updates application observability from 3scale-operator with information about:
- How to enable it
- How to disabled alerts management
- What kind of resources are created and why

In addition, there was a mix of links to 3scale-operator repo `master` and `specific releases` branches:
- 3scale-operator repo `master` is very stable, no link has been broken since this repo was created 4 hears ago
- Links to specific releases branches can become obsolete with time
- As most of the links were already pointing to master, I have updated the ones that not (were pointing to very old 2.10) to point to master